### PR TITLE
Remove cython as run dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,10 +13,10 @@ build:
 
 requirements:
   build:
-    - python
+    - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython >=0.27,<3
-    - {{ pin_compatible('numpy') }}
+    - cython >=0.27,<3                       # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
   host:
@@ -26,7 +26,7 @@ requirements:
     - setuptools
     - scikit-learn >=0.16
     - joblib
-    - {{ pin_compatible('numpy') }}
+    - numpy
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,15 +8,15 @@ source:
   url: https://pypi.io/packages/source/h/hdbscan/hdbscan-{{ version }}.tar.gz
   sha256: d398acb69e0c4ebdf539c2ba5839c523360ec814f300faa7f2f87de8f257af58
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
+    - python
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython >=0.27,<3                       # [build_platform != target_platform]
-    - numpy                                  # [build_platform != target_platform]
+    - cython >=0.27,<3
+    - numpy
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
   host:
@@ -24,7 +24,6 @@ requirements:
     - pip
     - setuptools
     - scikit-learn >=0.16
-    - cython >=0.27,<3
     - joblib
     - numpy
 
@@ -33,7 +32,6 @@ requirements:
     - scikit-learn >=0.16
     - joblib
     - six
-    - cython >=0.27,<3
     - {{ pin_compatible('numpy') }}
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,16 +16,17 @@ requirements:
     - python
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - cython >=0.27,<3
-    - numpy
+    - {{ pin_compatible('numpy') }}
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
   host:
     - python
     - pip
+    - cython >=0.27,<3    
     - setuptools
     - scikit-learn >=0.16
     - joblib
-    - numpy
+    - {{ pin_compatible('numpy') }}
 
   run:
     - python


### PR DESCRIPTION
Remove cython dependencies from host & run sections.  Also, remove `build_platform != target_platform` checks from python, cython, and numpy dependencies in build section.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Addresses #67 

<!--
Please add any other relevant info below:
-->
